### PR TITLE
detect parameters for bcrypt

### DIFF
--- a/src/main/java/com/password4j/HashChecker.java
+++ b/src/main/java/com/password4j/HashChecker.java
@@ -189,7 +189,7 @@ public class HashChecker
      */
     public boolean withBCrypt()
     {
-        return with(AlgorithmFinder.getBCryptInstance());
+        return with(BCryptFunction.getInstanceFromHash(hashed));
     }
 
     /**


### PR DESCRIPTION
Fix for issue https://github.com/Password4j/password4j/issues/18

### Test:
```
String hash = "$2b$12$fRnFJP6V1PybWlgvGYYeEutnpgtmYPBy94UPwpKfH2J5GbxA22cFC";
String password = "1234";
boolean verified = Password.check(password, hash).withBCrypt();
```
### Result:
`false` become `true`.