### PR TITLE
Argon2.java: simplify code in the constructor

### DIFF
--- a/src/main/java/com/password4j/Argon2Function.java
+++ b/src/main/java/com/password4j/Argon2Function.java
@@ -86,17 +86,10 @@ public class Argon2Function extends AbstractHashingFunction
         this.outputLength = outputLength;
         this.version = version;
 
-        int memoryBlocks = this.memory;
-
-        if (this.memory < 2 * ARGON2_SYNC_POINTS * parallelism)
-        {
-            memoryBlocks = 2 * ARGON2_SYNC_POINTS * parallelism;
-        }
-
-        segmentLength = memoryBlocks / (parallelism * ARGON2_SYNC_POINTS);
+        int j = ARGON2_SYNC_POINTS * parallelism;
+        int memoryBlocks = Math.max(this.memory, 2 * j);
+        segmentLength = memoryBlocks / j;
         this.laneLength = segmentLength * ARGON2_SYNC_POINTS;
-
-        memoryBlocks = segmentLength * (parallelism * ARGON2_SYNC_POINTS);
 
         initialBlockMemory = new long[memoryBlocks][ARGON2_QWORDS_IN_BLOCK];
         for (int i = 0; i < memoryBlocks; i++)


### PR DESCRIPTION
We have:
```
segmentLength = memoryBlocks / (parallelism * ARGON2_SYNC_POINTS);
memoryBlocks = segmentLength * (parallelism * ARGON2_SYNC_POINTS);
```

Which equals:
```
memoryBlocks = (memoryBlocks / (parallelism * ARGON2_SYNC_POINTS)) *
(parallelism * ARGON2_SYNC_POINTS);
```
Which is:
```
memoryBlocks = memoryBlocks;
```

As a consequence, we can remove this assignment to self.