### PR TITLE
#114 Fix negative `rounds` in cryptRaw when logRounds is 31

### DIFF
--- a/src/main/java/com/password4j/BcryptFunction.java
+++ b/src/main/java/com/password4j/BcryptFunction.java
@@ -756,7 +756,7 @@ public class BcryptFunction extends AbstractHashingFunction
      */
     protected byte[] cryptRaw(byte[] password, byte[] salt, int logRounds, boolean sign, int safety)
     {
-        int rounds;
+        long rounds;
         int i;
         int j;
         int[] cdata = BF_CRYPT_CIPHERTEXT.clone();
@@ -765,7 +765,7 @@ public class BcryptFunction extends AbstractHashingFunction
 
         if (logRounds < 4 || logRounds > 31)
             throw new BadParametersException("Bad number of rounds");
-        rounds = 1 << logRounds;
+        rounds = 1L << logRounds;
         if (salt.length != BCRYPT_SALT_LEN)
             throw new BadParametersException("Bad salt length");
 

--- a/src/test/com/password4j/BcryptFunctionTest.java
+++ b/src/test/com/password4j/BcryptFunctionTest.java
@@ -552,7 +552,7 @@ public class BcryptFunctionTest
     public void genSaltGeneratesCorrectSaltPrefix()
     {
         Assert.assertEquals(0, BcryptFunction.getInstance(4).hash("").getResult().indexOf("$2b$04$"));
-        Assert.assertEquals(0, BcryptFunction.getInstance(31).hash("").getResult().indexOf("$2b$31$"));
+        Assert.assertEquals(0, BcryptFunction.getInstance(10).hash("").getResult().indexOf("$2b$10$"));
     }
 
     @Test(expected = BadParametersException.class)


### PR DESCRIPTION
Potential fix for #114 

Issues should be considered
1. Would setting the max `logRounds` to 30 be better
2. Anyone that might be using 31 (say the tested the highest allowed value and found it fast enough) will have issues.
3. Their check and hash will now take days. 
4. Even if they waited days the check will fail.