### PR TITLE
fix addRandomSalt

### DIFF
--- a/src/main/java/com/password4j/HashBuilder.java
+++ b/src/main/java/com/password4j/HashBuilder.java
@@ -95,7 +95,7 @@ public class HashBuilder
      */
     public HashBuilder addRandomSalt()
     {
-        this.salt = SaltGenerator.generate();
+        addSalt(new String(SaltGenerator.generate(), Utils.DEFAULT_CHARSET));
         return this;
     }
 
@@ -117,7 +117,7 @@ public class HashBuilder
         }
         else
         {
-            this.salt = SaltGenerator.generate(length);
+            addSalt(new String(SaltGenerator.generate(length), Utils.DEFAULT_CHARSET));
         }
         return this;
     }

--- a/src/test/com/password4j/Argon2FunctionTest.java
+++ b/src/test/com/password4j/Argon2FunctionTest.java
@@ -147,6 +147,16 @@ public class Argon2FunctionTest
         }
     }
 
+    @Test
+    public void testWithGeneratedSalt()
+    {
+        for (TestCase test : CASES)
+        {
+            Argon2Function f = getFunction(test.memory, test.iterations, test.parallelism, test.outLength, test.type, test.version);
+            Hash hash = Password.hash(test.plainTextPassword).addRandomSalt(128).with(f);
+            assertTrue(Password.check(test.plainTextPassword, hash));
+        }
+    }
 
     @Test
     public void parallelTest() throws InterruptedException, ExecutionException

--- a/src/test/com/password4j/Argon2FunctionTest.java
+++ b/src/test/com/password4j/Argon2FunctionTest.java
@@ -153,6 +153,17 @@ public class Argon2FunctionTest
         for (TestCase test : CASES)
         {
             Argon2Function f = getFunction(test.memory, test.iterations, test.parallelism, test.outLength, test.type, test.version);
+            Hash hash = Password.hash(test.plainTextPassword).addRandomSalt().with(f);
+            assertTrue(Password.check(test.plainTextPassword, hash));
+        }
+    }
+
+    @Test
+    public void testWithGeneratedSaltAndSetLenght()
+    {
+        for (TestCase test : CASES)
+        {
+            Argon2Function f = getFunction(test.memory, test.iterations, test.parallelism, test.outLength, test.type, test.version);
             Hash hash = Password.hash(test.plainTextPassword).addRandomSalt(128).with(f);
             assertTrue(Password.check(test.plainTextPassword, hash));
         }


### PR DESCRIPTION
**BUGFIX:**
Changing the default character set to `UTF-8` in `v1.7.3` seems to have broken `HashBuilder.addRandomSalt()` and `HashBuilder.addRandomSalt(int length)`. Using `addSalt(String salt)` with a properly encoded String fixes that.