### PR TITLE
Fix argon and balloon blocking application shutdown

### DIFF
--- a/src/main/java/com/password4j/Argon2Function.java
+++ b/src/main/java/com/password4j/Argon2Function.java
@@ -101,7 +101,7 @@ public class Argon2Function extends AbstractHashingFunction
 
         if (parallelism >= 1)
         {
-            service = Executors.newFixedThreadPool(Utils.AVAILABLE_PROCESSORS);
+            service = Utils.createExecutorService();
         }
     }
 

--- a/src/main/java/com/password4j/BalloonHashingFunction.java
+++ b/src/main/java/com/password4j/BalloonHashingFunction.java
@@ -59,7 +59,7 @@ public class BalloonHashingFunction extends AbstractHashingFunction
         this.delta = delta;
         if (parallelism > 1)
         {
-            this.service = Executors.newFixedThreadPool(Utils.AVAILABLE_PROCESSORS);
+            this.service = Utils.createExecutorService();
         }
 
     }

--- a/src/main/java/com/password4j/Utils.java
+++ b/src/main/java/com/password4j/Utils.java
@@ -32,6 +32,9 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,6 +52,10 @@ class Utils
             '/' };
 
     private static final int[] FROM_BASE64 = new int[256];
+
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
+
+    private static final ThreadGroup THREAD_GROUP = new ThreadGroup("Password4j Workers");
 
     static
     {
@@ -655,6 +662,11 @@ class Utils
         return byteArrays;
     }
 
-
-
+    static ExecutorService createExecutorService() {
+        return Executors.newFixedThreadPool(AVAILABLE_PROCESSORS, runnable -> {
+            Thread thread = new Thread(THREAD_GROUP, runnable, "password4j-worker-" + THREAD_COUNTER.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
 }


### PR DESCRIPTION
If you set the parallelism of `Argon2Function` or `BalloonHashingFunction` above `1` and that you hash something (anything), a non daemon `ExecutorService` will be created, which can block the application shutdown if there is no explicit `System.exit`.

This PR fixes this by making the threads of the created `ExecutorService` daemon.
And also add names and a dedicated thread groups for password4j threads, making debugging that kind of issue **MUCH** easier (I had to trace every thread pool creation to figure the issue out).