### PR TITLE
Prevent password leak in memory

### DIFF
--- a/src/main/java/com/password4j/PBKDF2Function.java
+++ b/src/main/java/com/password4j/PBKDF2Function.java
@@ -128,7 +128,14 @@ public class PBKDF2Function extends AbstractHashingFunction
     {
         SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance(ALGORITHM_PREFIX + algorithm);
         PBEKeySpec spec = new PBEKeySpec(plain, salt, iterations, length);
-        return secretKeyFactory.generateSecret(spec);
+        try
+        {   
+            return secretKeyFactory.generateSecret(spec);
+        }
+        finally
+        {   
+            spec.clearPassword();
+        }
     }
 
     protected static String getUID(String algorithm, int iterations, int length)


### PR DESCRIPTION
TLDR; Call spec.clearPassword() to clear the internal copy of the password and prevent it from being leaked in memory.
See https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/PBEKeySpec.html

The plain text password is not cleared from memory after being used for key derivation in internalHash. This may leave sensitive data in memory longer than necessary, increasing the risk of exposure via memory dumps. After generating the secret key, we clear the sensitive password data from memory by refactoring the code to use a try-finally block that calls spec.clearPassword() after secretKeyFactory.generateSecret(spec).

Additional details and PoC available on request.

